### PR TITLE
Email auth

### DIFF
--- a/app/controllers/pomodoro_tags_controller.rb
+++ b/app/controllers/pomodoro_tags_controller.rb
@@ -1,4 +1,6 @@
 class PomodoroTagsController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     pomodorotags = PomodoroTag.all
     # ?tag_id=1

--- a/app/controllers/pomodoros_controller.rb
+++ b/app/controllers/pomodoros_controller.rb
@@ -1,4 +1,5 @@
 class PomodorosController < ApplicationController
+  before_action :authenticate_user!
 
   def index
     pomodoros = Pomodoro.all

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,4 +1,6 @@
 class TagsController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     tags = Tag.all
     render json: {status: 'SUCCESS', message: 'Loaded all tags', data: tags}, status: :ok

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules.
   devise :database_authenticatable, :registerable,
-          :recoverable, :rememberable, :trackable, :validatable,
+          :recoverable, :rememberable, :trackable, :validatable#,
           # :confirmable , :omniauthable
   include DeviseTokenAuth::Concerns::User
   has_many :pomodoros

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules.
   devise :database_authenticatable, :registerable,
           :recoverable, :rememberable, :trackable, :validatable,
-          :confirmable #, :omniauthable
+          # :confirmable , :omniauthable
   include DeviseTokenAuth::Concerns::User
   has_many :pomodoros
 end

--- a/db/migrate/20161220211405_devise_token_auth_create_users.rb
+++ b/db/migrate/20161220211405_devise_token_auth_create_users.rb
@@ -23,10 +23,10 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[5.0]
       t.string   :last_sign_in_ip
 
       ## Confirmable
-      t.string   :confirmation_token
-      t.datetime :confirmed_at
-      t.datetime :confirmation_sent_at
-      t.string   :unconfirmed_email # Only if using reconfirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, :default => 0, :null => false # Only if lock strategy is :failed_attempts

--- a/spec/controllers/pomodoro_tags_controller_spec.rb
+++ b/spec/controllers/pomodoro_tags_controller_spec.rb
@@ -2,17 +2,27 @@ require 'rails_helper'
 
 RSpec.describe PomodoroTagsController, type: :controller do
   describe "GET #index" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+
+    # it "responds with status code 200" do
+    #   get :index
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 
   describe "GET #show" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       pomodorotag = FactoryGirl.create(:pomodoro_tag)
       get :show, params: { id: pomodorotag.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+    # it "responds with status code 200" do
+    #   pomodorotag = FactoryGirl.create(:pomodoro_tag)
+    #   get :show, params: { id: pomodorotag.id }
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 end

--- a/spec/controllers/pomodoro_tags_controller_spec.rb
+++ b/spec/controllers/pomodoro_tags_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe PomodoroTagsController, type: :controller do
+
+  it { should use_before_action(:authenticate_user!) }
+  
   describe "GET #index" do
     it "rejects non-authenticated users" do
       get :index

--- a/spec/controllers/pomodoros_controller_spec.rb
+++ b/spec/controllers/pomodoros_controller_spec.rb
@@ -2,17 +2,26 @@ require 'rails_helper'
 
 RSpec.describe PomodorosController, type: :controller do
   describe "GET #index" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+    # it "responds with status code 200" do
+    #   get :index
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 
   describe "GET #show" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       pomodoro = FactoryGirl.create(:pomodoro)
       get :show, params: { id: pomodoro.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+    # it "responds with status code 200" do
+    #   pomodoro = FactoryGirl.create(:pomodoro)
+    #   get :show, params: { id: pomodoro.id }
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 end

--- a/spec/controllers/pomodoros_controller_spec.rb
+++ b/spec/controllers/pomodoros_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe PomodorosController, type: :controller do
+
+  it { should use_before_action(:authenticate_user!) }  
+
   describe "GET #index" do
     it "rejects non-authenticated users" do
       get :index

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do
+
+  it { should use_before_action(:authenticate_user!) }
+
   describe "GET #index" do
     it "rejects non-authenticated users" do
       get :index

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -2,17 +2,27 @@ require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do
   describe "GET #index" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+
+    # it "responds with status code 200" do
+    #   get :index
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 
   describe "GET #show" do
-    it "responds with status code 200" do
+    it "rejects non-authenticated users" do
       tag = FactoryGirl.create(:tag)
       get :show, params: { id: tag.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(401)
     end
+    # it "responds with status code 200" do
+    #   tag = FactoryGirl.create(:tag)
+    #   get :show, params: { id: tag.id }
+    #   expect(response).to have_http_status(:success)
+    # end
   end
 end


### PR DESCRIPTION
Hey @seanyboy49! I disabled email confirmation (register + click confirmation link) in Devise. You can now sign in and sign out with an email address. I've been trying out requests in Postman and it *seems* to be working. I'll need your help getting an email sign-in form working on the frontend. Here's the [jToker email sign-in component](https://github.com/lynndylanhurley/j-toker/blob/master/demo/src/scripts/components/login-form.jsx) for reference.

## Sign-in
POST --> http://localhost:3000/auth/sign_in
Give `email` and `password` as params and check the JSON response for `access-token`, `uid`, and `client`

## Sign-out
DELETE --> http://localhost:3000/auth/sign_out
Give `access-token`, `uid`, and `client` as params

## Validate token
give a token, get a new token!
GET --> http://localhost:3000/auth/validate_token
Give `access-token`, `uid`, and `client` as params and receive a new `access-token`
